### PR TITLE
Have curl return a proper exit code when failing

### DIFF
--- a/scripts/hot-export-fetch.sh
+++ b/scripts/hot-export-fetch.sh
@@ -6,7 +6,7 @@ echo "      temp dir: "$2
 echo
 
 mkdir -p $2
-curl $1 | pv | tar xzf - -C $2
+curl -fL $1 | tar xzf - -C $2
 
 echo "==> hot-export-fetch.sh : END"
 echo

--- a/scripts/posm-aoi-reset.sh
+++ b/scripts/posm-aoi-reset.sh
@@ -20,7 +20,7 @@ echo "==> posm-aoi-reset.sh"
 echo "      aoi name: "$aoi_name
 
 # Activate aoi
-curl --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
+curl -f --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
 
 # Drop and create API DB
 # sudo -u postgres /opt/admin/posm-admin/scripts/postgres_api-db-drop-create.sh

--- a/scripts/posm-deploy-full.sh
+++ b/scripts/posm-deploy-full.sh
@@ -35,7 +35,7 @@ echo
 $scripts_dir/hot-export-move.sh $tmp_dir $aoi_dir
 
 # Activate aoi
-curl --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
+curl -f --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
 
 # Drop and create API DB
 # sudo -u postgres /opt/admin/posm-admin/scripts/postgres_api-db-drop-create.sh


### PR DESCRIPTION
Now follows redirects when fetching POSM Bundles.

Also drops the dependency on pv, as curl already displays progress.

Fixes AmericanRedCross/posm#169