### PR TITLE
Remove hard-coded posm.io hostname

### DIFF
--- a/scripts/posm-aoi-reset.sh
+++ b/scripts/posm-aoi-reset.sh
@@ -22,7 +22,7 @@ echo "==> posm-aoi-reset.sh"
 echo "      aoi name: "$aoi_name
 
 # Activate aoi
-curl -f --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
+curl -f --data "aoi_name=$aoi_name" "$(jq -r .posm_base_url /etc/posm.json)/posm-admin/status/activate-aoi"
 
 # Drop and create API DB
 # sudo -u postgres /opt/admin/posm-admin/scripts/postgres_api-db-drop-create.sh

--- a/scripts/posm-deploy-full.sh
+++ b/scripts/posm-deploy-full.sh
@@ -37,7 +37,7 @@ echo
 $scripts_dir/hot-export-move.sh $tmp_dir $aoi_dir
 
 # Activate aoi
-curl -f --data "aoi_name=$aoi_name" http://posm.io/posm-admin/status/activate-aoi
+curl -f --data "aoi_name=$aoi_name" "$(jq -r .posm_base_url /etc/posm.json)/posm-admin/status/activate-aoi"
 
 # Drop and create API DB
 # sudo -u postgres /opt/admin/posm-admin/scripts/postgres_api-db-drop-create.sh


### PR DESCRIPTION
Uses `jq` to pull the config from the global registry of settings.