### PR TITLE
Add a workaround for ssid not being changed on reboot

### DIFF
--- a/scripts/root_change-ssid.sh
+++ b/scripts/root_change-ssid.sh
@@ -20,6 +20,12 @@ new_ssid=$1
 jq ". | .posm_ssid |= \"$new_ssid\"" /etc/posm.json | sponge /etc/posm.json
 sed -ri "s/^(ssid2=).*/\1\"${new_ssid}\"/" /etc/hostapd/hostapd.conf
 
+# Since on reboot hostapd reads the config from /root/etc instead from /etc,
+# Make corresponding changes inside /root/etc as well. This will fix the issue
+# of SSID not being reset on reboot.
+jq ". | .posm_ssid |= \"$new_ssid\"" /root/etc/posm.json | sponge /root/etc/posm.json
+sed -ri "s/^(ssid2=).*/\1\"${new_ssid}\"/" /root/etc/hostapd.conf
+
 killall -HUP hostapd
 
 echo "==> $0: END."


### PR DESCRIPTION
This is a workaround for SSID not being changed on reboot. Changes:
- Update ssid value in `/root/posm-build/kickstart/etc/` files along with `/etc/` files as posm seems to take configs from `/root/posm-build/kickstart/etc/` on reboot.

Fixes: https://github.com/posm/posm/issues/354